### PR TITLE
Add ast-grep configuration with Rust lint rules

### DIFF
--- a/rules/no-dbg-macro.yml
+++ b/rules/no-dbg-macro.yml
@@ -4,3 +4,4 @@ rule:
   pattern: dbg!($$$)
 message: Remove `dbg!()` macro before committing — it's intended for local debugging only.
 severity: warning
+note: dbg!() writes to stderr and should not be left in production code. Remove it or replace with proper logging.

--- a/rules/no-dbg-macro.yml
+++ b/rules/no-dbg-macro.yml
@@ -1,0 +1,6 @@
+id: no-dbg-macro
+language: rust
+rule:
+  pattern: dbg!($$$)
+message: Remove `dbg!()` macro before committing — it's intended for local debugging only.
+severity: warning

--- a/rules/no-println-in-lib.yml
+++ b/rules/no-println-in-lib.yml
@@ -1,0 +1,14 @@
+id: no-println-in-lib
+language: rust
+rule:
+  pattern: println!($$$)
+  inside:
+    kind: function_item
+    not:
+      has:
+        kind: identifier
+        regex: "^main$"
+    stopBy: end
+message: Prefer structured logging (e.g., `log` or `tracing` crate) over `println!` in non-main functions.
+severity: hint
+note: println! is fine in main() but library/helper functions should use proper logging.

--- a/rules/no-todo-macro.yml
+++ b/rules/no-todo-macro.yml
@@ -1,0 +1,6 @@
+id: no-todo-macro
+language: rust
+rule:
+  pattern: todo!($$$)
+message: Replace `todo!()` with an implementation or a tracked issue before merging.
+severity: warning

--- a/rules/no-todo-macro.yml
+++ b/rules/no-todo-macro.yml
@@ -4,3 +4,4 @@ rule:
   pattern: todo!($$$)
 message: Replace `todo!()` with an implementation or a tracked issue before merging.
 severity: warning
+note: todo!() panics at runtime. Implement the missing logic or file a tracking issue before merging.

--- a/rules/no-unwrap.yml
+++ b/rules/no-unwrap.yml
@@ -1,0 +1,7 @@
+id: no-unwrap
+language: rust
+rule:
+  pattern: $EXPR.unwrap()
+message: Avoid using `.unwrap()` — prefer `.expect("reason")`, `?`, or proper error handling.
+severity: warning
+note: unwrap() causes a panic with no context on failure. Use expect() with a message or handle the error explicitly.

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,2 @@
+ruleDirs:
+  - rules

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,19 @@ fn mainish() {
     println!("5 - 3 = {}", subtract(5, 3));
     println!("4 * 3 = {}", multiply(4, 3));
 }
+
+fn parse_number(input: &str) -> i32 {
+    input.parse::<i32>().unwrap()
+}
+
+fn divide(a: i32, b: i32) -> i32 {
+    if b == 0 {
+        todo!()
+    }
+    let result = a / b;
+    dbg!(result);
+    result
+}
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
- Add ast-grep project config (`sgconfig.yml`) and four custom Rust lint rules: `no-unwrap`, `no-dbg-macro`, `no-todo-macro`, `no-println-in-lib`
- Add sample code with intentional violations in `src/main.rs` for testing qlty integration

## Test plan
- [ ] Run `ast-grep scan` and verify all 4 rules produce violations
- [ ] Verify qlty detects the ast-grep findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)